### PR TITLE
Add file extension to support GPG (GNU Privacy Guard) tools.

### DIFF
--- a/types/application.yaml
+++ b/types/application.yaml
@@ -2147,6 +2147,7 @@
   - class
   - ani
   - pgp
+  - gpg
   - so
   - dll
   - dylib
@@ -2303,6 +2304,7 @@
   encoding: 7bit
   extensions:
   - pgp
+  - gpg
   xrefs: !ruby/object:MIME::Types::Container
     rfc:
     - rfc3156


### PR DESCRIPTION
Most of the GPG tools encrypt and decrypt with .gpg extension rather
than .pgp. https://en.wikipedia.org/wiki/GNU_Privacy_Guard

Some tools like GPGServices on Mac doesn't even recognise .pgp which seems to be another reason to support .gpg in MIME. See: https://gpgtools.tenderapp.com/discussions/problems/21881-use-pgp-file-extension-to-decrypt-files-os-x-mavericks