### PR TITLE
Add .xsd extension to XML mime

### DIFF
--- a/types/text.yaml
+++ b/types/text.yaml
@@ -959,6 +959,7 @@
   extensions:
   - xml
   - dtd
+  - xsd
   xrefs: !ruby/object:MIME::Types::Container
     rfc:
     - rfc7303


### PR DESCRIPTION
An XML Schema file has the extension `.xsd` and its mime type is `text/xml`.