### PR TITLE
Update JS MIME type file extensions

### DIFF
--- a/data/mime.content_type.column
+++ b/data/mime.content_type.column
@@ -83,7 +83,7 @@ application/dssc+der dssc
 application/dssc+xml xdssc
 application/dvcs
 application/dxf
-application/ecmascript ecma
+application/ecmascript js ecma mjs
 application/EDI-consent
 application/EDI-X12
 application/EDIFACT
@@ -143,7 +143,7 @@ application/its+xml
 application/java-archive jar
 application/java-serialized-object ser
 application/java-vm class
-application/javascript js sj
+application/javascript js mjs sj
 application/jose
 application/jose+json
 application/jrd+json
@@ -1314,7 +1314,7 @@ application/x-java-archive jar
 application/x-java-jnlp-file jnlp
 application/x-java-serialized-object ser
 application/x-java-vm class
-application/x-javascript js
+application/x-javascript js mjs
 application/x-koan skp skd skt skm
 application/x-latex ltx latex
 application/x-lotus-123 wks
@@ -1771,14 +1771,14 @@ text/csv csv
 text/csv-schema
 text/directory
 text/dns
-text/ecmascript
+text/ecmascript js mjs
 text/encaprtp
 text/enriched
 text/example
 text/fwdred
 text/grammar-ref-list
 text/html html htm htmlx shtml htx
-text/javascript js
+text/javascript js mjs
 text/jcr-cnd
 text/markdown
 text/mizar

--- a/types/application.yaml
+++ b/types/application.yaml
@@ -808,6 +808,8 @@
   encoding: base64
   extensions:
   - ecma
+  - js
+  - mjs
   xrefs: !ruby/object:MIME::Types::Container
     rfc:
     - rfc4329
@@ -1366,6 +1368,7 @@
   encoding: 8bit
   extensions:
   - js
+  - mjs
   - sj
   xrefs: !ruby/object:MIME::Types::Container
     rfc:
@@ -13511,6 +13514,7 @@
   encoding: 8bit
   extensions:
   - js
+  - mjs
   obsolete: true
   use-instead: application/javascript
   registered: false

--- a/types/text.yaml
+++ b/types/text.yaml
@@ -105,6 +105,9 @@
 - !ruby/object:MIME::Type
   content-type: text/ecmascript
   encoding: quoted-printable
+  extensions:
+  - js
+  - mjs
   obsolete: true
   use-instead: application/ecmascript
   xrefs: !ruby/object:MIME::Types::Container
@@ -181,6 +184,7 @@
   encoding: quoted-printable
   extensions:
   - js
+  - mjs
   obsolete: true
   use-instead: application/javascript
   xrefs: !ruby/object:MIME::Types::Container


### PR DESCRIPTION
This adds some `js` file extensions that were missing for [JS MIMEs](https://html.spec.whatwg.org/multipage/scripting.html#javascript-mime-type). It also adds `mjs` from the [upcoming Internet Draft](https://datatracker.ietf.org/doc/draft-bfarias-javascript-mjs/) which Node.js will be using for ES Modules.