### PR TITLE
Added ipa extention to application/octet-stream mime type definition

### DIFF
--- a/types/application.yaml
+++ b/types/application.yaml
@@ -2170,6 +2170,7 @@
   - lrf
   - mar
   - pkg
+  - ipa
   xrefs: !ruby/object:MIME::Types::Container
     rfc:
     - rfc2045


### PR DESCRIPTION
Provides support for .ipa files. mime-types-data is a dependency of a ruby gem I'm using in a continuous integration solution. The lack of ipa extension support was causing a mime-type conflict when submitting ipa files to our MDM server.