### PR TITLE
Fix #15: Move `.md`, and `.markdown`

### DIFF
--- a/types/text.yaml
+++ b/types/text.yaml
@@ -203,6 +203,9 @@
 - !ruby/object:MIME::Type
   content-type: text/markdown
   encoding: quoted-printable
+  extensions:
+  - markdown
+  - md
   xrefs: !ruby/object:MIME::Types::Container
     rfc:
     - rfc7763
@@ -270,8 +273,6 @@
   - in
   - list
   - log
-  - markdown
-  - md
   - rst
   - text
   - textile


### PR DESCRIPTION
This moves the `.markdown`, and `.md` extensions from `text/plain` into `text/markdown` as recommended on RFC 7763.