### PR TITLE
Fix extensions for ecmascript types

### DIFF
--- a/data/mime.content_type.column
+++ b/data/mime.content_type.column
@@ -94,7 +94,7 @@ application/dssc+der dssc
 application/dssc+xml xdssc
 application/dvcs
 application/dxf
-application/ecmascript ecma js mjs
+application/ecmascript ecma es
 application/EDI-consent
 application/EDI-X12
 application/EDIFACT
@@ -1938,7 +1938,7 @@ text/csv csv
 text/csv-schema
 text/directory
 text/dns
-text/ecmascript js mjs
+text/ecmascript es ecma
 text/encaprtp
 text/enriched
 text/example

--- a/types/application.yaml
+++ b/types/application.yaml
@@ -912,8 +912,7 @@
   encoding: base64
   extensions:
   - ecma
-  - js
-  - mjs
+  - es
   xrefs:
     rfc:
     - rfc4329

--- a/types/text.yaml
+++ b/types/text.yaml
@@ -106,8 +106,8 @@
   content-type: text/ecmascript
   encoding: quoted-printable
   extensions:
-  - js
-  - mjs
+  - es
+  - ecma
   obsolete: true
   use-instead: application/ecmascript
   xrefs:


### PR DESCRIPTION
According to [RFC4329](https://tools.ietf.org/html/rfc4329) both `application/ecmascript` and `text/ecmascript` are associated with extension `.es` and not `.js`. The [draft RFC](https://tools.ietf.org/html/draft-bfarias-javascript-mjs-01) that adds `.mjs` support does not change those assignments either.

Moreover, according to RFC4329, `application/ecmascript` has stricter processing rules, so applications should not be returning that MIME type for Javascript files without opting in to those stricter rules.

PR https://github.com/mime-types/mime-types-data/pull/11, however, introduced a regression by adding `.js` and `.mjs` as extensions for `application/ecmascript` and `text/ecmascript`. This PR fixes that regression.