### PR TITLE
Add support for WebAssembly type

### DIFF
--- a/types/application.yaml
+++ b/types/application.yaml
@@ -14028,6 +14028,19 @@
     - application/vq-rtcpxr
   registered: true
 - !ruby/object:MIME::Type
+  content-type: application/wasm
+  friendly:
+    en: WebAssembly
+  encoding: 8bit
+  extensions:
+  - wasm
+  xrefs:
+    uri:
+    - https://www.w3.org/TR/wasm-web-api-1/
+    template:
+    - application/wasm
+  registered: true
+- !ruby/object:MIME::Type
   content-type: application/watcherinfo+xml
   encoding: base64
   extensions:


### PR DESCRIPTION
WebAssembly binary files with the extension `.wasm` should be given the `application/wasm` MIME type, see https://www.w3.org/TR/wasm-web-api-1/.