### PR TITLE
Give pdf extension higher priority

### DIFF
--- a/types/application.yaml
+++ b/types/application.yaml
@@ -2679,8 +2679,8 @@
     en: Adobe Portable Document Format
   encoding: base64
   extensions:
+  - pdf  
   - ai
-  - pdf
   xrefs:
     rfc:
     - rfc8118


### PR DESCRIPTION
After #23 (#22) now the `.preferred_extension` for `application/pdf` is `ai` which is not fully correct.