### PR TITLE
Add application/x-compressed-zip

### DIFF
--- a/types/application.yaml
+++ b/types/application.yaml
@@ -16684,7 +16684,7 @@
     - application/zip
   registered: true
 - !ruby/object:MIME::Type
-  content-type: application/x-compressed-zip
+  content-type: application/x-zip-compressed
   friendly:
     en: Zip Archive
   encoding: base64

--- a/types/application.yaml
+++ b/types/application.yaml
@@ -16684,6 +16684,14 @@
     - application/zip
   registered: true
 - !ruby/object:MIME::Type
+  content-type: application/x-compressed-zip
+  friendly:
+    en: Zip Archive
+  encoding: base64
+  extensions:
+  - zip
+  registered: false
+- !ruby/object:MIME::Type
   content-type: application/zlib
   encoding: base64
   xrefs:


### PR DESCRIPTION
Hi,

I came across https://github.com/mime-types/mime-types-data/issues/17 while debugging an issue and saw that you said (way back in August 2018) that you'd be willing to accept a PR adding support for this content type.

A user somehow uploaded a file with the `application/x-zip-compressed` content type to us and now we're having some errors because it's not recognised by the gem 😅 

Not sure if this change is right... I based it on https://github.com/mime-types/mime-types-data/pull/31/files so hopefully it's not far off 😄 I wasn't sure what the `template` or `registered` keys were for?

Thanks,

Alex