### PR TITLE
Add .avif extension to image/avif

### DIFF
--- a/types/image.yaml
+++ b/types/image.yaml
@@ -32,6 +32,8 @@
 - !ruby/object:MIME::Type
   content-type: image/avif
   encoding: base64
+  extensions:
+    - avif
   xrefs:
     person:
     - Alliance_for_Open_Media


### PR DESCRIPTION
I couldn't find any extensions other than `.avif` for this format. There's a related format, `image/avif-sequence`, which uses the `.avifs` extension, but it's not in the IANA list at this time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mime-types/mime-types-data/40)
<!-- Reviewable:end -->
