### PR TITLE
Add JPEG XL (image/jxl)

### DIFF
--- a/types/image.yaml
+++ b/types/image.yaml
@@ -257,6 +257,17 @@
     - rfc2046
   registered: true
 - !ruby/object:MIME::Type
+  content-type: image/jxl
+  friendly:
+    en: JPEG XL Image
+  encoding: base64
+  extensions:
+  - jxl
+  xrefs:
+    person:
+    - ISO-IEC_JTC1
+  registered: true
+- !ruby/object:MIME::Type
   content-type: image/jph
   encoding: base64
   xrefs:


### PR DESCRIPTION
JPEG XL, image/jxl, ISO/IEC 18181.
More information can be found here:

- https://jpeg.org/jpegxl
- https://jpegxl.info

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mime-types/mime-types-data/43)
<!-- Reviewable:end -->
