### PR TITLE
Added 'vtt' file extension to WebVTT mime type (text/vtt).

### DIFF
--- a/types/text.yaml
+++ b/types/text.yaml
@@ -989,6 +989,8 @@
 - !ruby/object:MIME::Type
   content-type: text/vtt
   encoding: quoted-printable
+  extensions:
+  - vtt
   xrefs:
     person:
     - Silvia_Pfeiffer


### PR DESCRIPTION
I stumbled upon `MIME::Types.type_for(...)` (using `ruby-mime-types`) not giving any results for `.vtt` files (WebVTT, mime type 'text/vtt', https://www.w3.org/TR/webvtt1/).

Further observation showed that the mime type `text/vtt` was actually added in Update 3.2020.0425 (8ee4e6b), but it did not reference any file extensions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mime-types/mime-types-data/46)
<!-- Reviewable:end -->
