### PR TITLE
Add JFIF extension to image/jpeg

### DIFF
--- a/types/image.yaml
+++ b/types/image.yaml
@@ -249,6 +249,7 @@
   - jpeg
   - jpg
   - jpe
+  - jfif
   xrefs:
     rfc:
     - rfc2045


### PR DESCRIPTION
**Context:** While using `MIME::Types.type_for` method to identify the file content type I noticed that JFIF extension is missing when it should be considered as `image/jpeg`

Fixes https://github.com/mime-types/mime-types-data/issues/51

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mime-types/mime-types-data/52)
<!-- Reviewable:end -->
