### PR TITLE
Add JXL extension to image/jxl

### DIFF
--- a/types/image.yaml
+++ b/types/image.yaml
@@ -347,6 +347,8 @@
 - !ruby/object:MIME::Type
   content-type: image/jxl
   encoding: base64
+  extensions:
+    - jxl
   xrefs:
     person:
     - ISO-IEC_JTC_1


### PR DESCRIPTION
I noticed that the JXL extension was missing from image/jxl. This was causing issues for the Jekyll plugin [jekyll_picture_tag](https://github.com/rbuchberger/jekyll_picture_tag) when trying to generate JPEG XL images.