### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/mime-types-data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <!-- automatic-release -->
 
+## NEXT / YYYY-MM-DD
+
+- Added `changelog_uri` to gemspec metadata to provide `Changelog` link on
+  Rubygems.org [#96][#96].
+
 ## 3.2025.0107 / 2025-01-07
 
 - Updated the Apache and IANA media registry entries as of release date
@@ -629,6 +634,7 @@
 [#55]: https://github.com/mime-types/mime-types-data/issues/55
 [#77]: https://github.com/mime-types/mime-types-data/pull/77
 [#81]: https://github.com/mime-types/mime-types-data/pull/81
+[#96]: https://github.com/mime-types/mime-types-data/pull/96
 [rmt]: https://github.com/mime-types/ruby-mime-types
 [code of conduct]: Code-of-Conduct.md
 [mini_mime]: https://github.com/discourse/mini_mime/issues/41

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,6 +32,7 @@ Thanks to everyone else who has contributed to mime-types:
 - Ken Ip
 - Łukasz Śliwa
 - Lucia
+- Mark Young
 - Martin d'Allens
 - Mauricio Linhares
 - Mohammed Gad

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 - home :: https://github.com/mime-types/mime-types-data/
 - issues :: https://github.com/mime-types/mime-types-data/issues
 - code :: https://github.com/mime-types/mime-types-data/
+- changelog :: https://github.com/mime-types/mime-types-data/blob/main/CHANGELOG.md
 
 ## Description
 

--- a/mime-types-data.gemspec
+++ b/mime-types-data.gemspec
@@ -6,10 +6,10 @@ Gem::Specification.new do |s|
   s.version = "3.2025.0107".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
-  s.metadata = { "bug_tracker_uri" => "https://github.com/mime-types/mime-types-data/issues", "homepage_uri" => "https://github.com/mime-types/mime-types-data/", "rubygems_mfa_required" => "true", "source_code_uri" => "https://github.com/mime-types/mime-types-data/" } if s.respond_to? :metadata=
+  s.metadata = { "bug_tracker_uri" => "https://github.com/mime-types/mime-types-data/issues", "changelog_uri" => "https://github.com/mime-types/mime-types-data/blob/main/CHANGELOG.md", "homepage_uri" => "https://github.com/mime-types/mime-types-data/", "rubygems_mfa_required" => "true", "source_code_uri" => "https://github.com/mime-types/mime-types-data/" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Austin Ziegler".freeze]
-  s.date = "2025-01-08"
+  s.date = "2025-01-13"
   s.description = "mime-types-data provides a registry for information about MIME media type\ndefinitions. It can be used with the Ruby mime-types library or other software\nto determine defined filename extensions for MIME types, or to use filename\nextensions to look up the likely MIME type definitions.".freeze
   s.email = ["halostatue@gmail.com".freeze]
   s.extra_rdoc_files = ["CHANGELOG.md".freeze, "CODE_OF_CONDUCT.md".freeze, "CONTRIBUTING.md".freeze, "CONTRIBUTORS.md".freeze, "LICENCE.md".freeze, "Manifest.txt".freeze, "README.md".freeze, "SECURITY.md".freeze]


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/mime-types-data which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/#metadata