### PR TITLE
chore: Handle promoted and withdrawn provisional IANA media types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@
   that format is obsolete by almost twenty years. Closes
   [ruby-mime-types#224][ruby-mime-types#224] with [#191][pull-191].
 
+- Handle promoted and withdrawn provisional IANA media types. Closes
+  [#54][issue-54] with [#192][pull-192].
+
+  The logic is three relatively simple phases:
+
+  1. When loading an existing registry grouping (such as
+     `types/application.yaml`), we mark any type that is `provisional` as
+     `obsolete`. This indicates that we consider any provisional type as
+     potentially withdrawn (and therefore obsolete).
+  2. When processing existing regular types, we clear both `provisional` and
+     `obsolete` flags so that a type promoted from provisional is now a regular
+     registry entry.
+  3. After merging the current list of registry entries, we _clear_
+     `provisional` if the type is marked both `provisional` and `obsolete`,
+     indicating that the provisional type has been withdrawn.
+
+  These heuristics match several types which have been promoted and withdrawn
+  since the handling of provisional types was improved with [#53][pull-53].
+
 ## 3.2025.0722 / 2025-07-22
 
 - Updated registry entries from the IANA [media registry][registry] and
@@ -632,13 +651,13 @@
 [issue-55]: https://github.com/mime-types/mime-types-data/issues/55
 [mini_mime]: https://github.com/discourse/mini_mime/issues/41
 [provisional]: https://www.iana.org/assignments/provisional-standard-media-types/provisional-standard-media-types.xml
-[pull-3]: https://github.com/mime-types/mime-types-data/pull/3
 [pull-109]: https://github.com/mime-types/mime-types-data/pull/109
-[pull-191]: https://github.com/mime-types/mime-types-data/pull/191
 [pull-10]: https://github.com/mime-types/mime-types-data/pull/10
 [pull-11]: https://github.com/mime-types/mime-types-data/pull/11
 [pull-12]: https://github.com/mime-types/mime-types-data/pull/12
 [pull-13]: https://github.com/mime-types/mime-types-data/pull/13
+[pull-191]: https://github.com/mime-types/mime-types-data/pull/191
+[pull-192]: https://github.com/mime-types/mime-types-data/pull/192
 [pull-20]: https://github.com/mime-types/mime-types-data/pull/20
 [pull-21]: https://github.com/mime-types/mime-types-data/pull/21
 [pull-23]: https://github.com/mime-types/mime-types-data/pull/23
@@ -651,6 +670,7 @@
 [pull-34]: https://github.com/mime-types/mime-types-data/pull/34
 [pull-35]: https://github.com/mime-types/mime-types-data/pull/35
 [pull-36]: https://github.com/mime-types/mime-types-data/pull/36
+[pull-3]: https://github.com/mime-types/mime-types-data/pull/3
 [pull-40]: https://github.com/mime-types/mime-types-data/pull/40
 [pull-43]: https://github.com/mime-types/mime-types-data/pull/43
 [pull-45]: https://github.com/mime-types/mime-types-data/pull/45

--- a/support/iana_registry.rb
+++ b/support/iana_registry.rb
@@ -110,8 +110,9 @@ class IANARegistry
         existing_types.each do |mt|
           mt.registered = true
           mt.xrefs = xrefs
-          mt.obsolete = obsolete if obsolete
+          mt.obsolete = obsolete
           mt.use_instead = use_instead if use_instead
+          mt.provisional = @provisional
         end
       end
     end
@@ -140,11 +141,14 @@ class IANARegistry
           emt.xrefs = mt.xrefs
           emt.registered = mt.registered
           emt.provisional = mt.provisional
-          emt.provisional = mt.provisional
           emt.obsolete = mt.obsolete
           emt.use_instead = mt.use_instead
         end
       end
+    end
+
+    @types.each do |t|
+      t.provisional = false if t.provisional && t.obsolete
     end
   end
 
@@ -154,6 +158,10 @@ class IANARegistry
     MIME::Types.new.tap do |container|
       if file.exist? && !@provisional
         container.add(*MIME::Types::Loader.load_from_yaml(file), :silent)
+
+        container.each do |t|
+          t.obsolete = true if t.provisional
+        end
       end
     end
   end

--- a/types/application.yaml
+++ b/types/application.yaml
@@ -662,8 +662,7 @@
     template:
     - application/bufr
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 16
 - !ruby/object:MIME::Type
   content-type: application/c2pa
   encoding: base64
@@ -912,8 +911,7 @@
     template:
     - application/ce+cbor
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 16
 - !ruby/object:MIME::Type
   content-type: application/CEA
   encoding: base64
@@ -983,8 +981,7 @@
     template:
     - application/cid
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 16
 - !ruby/object:MIME::Type
   content-type: application/cid-edhoc+cbor-seq
   encoding: base64
@@ -1005,8 +1002,7 @@
     template:
     - application/city+json
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 16
 - !ruby/object:MIME::Type
   content-type: application/city+json-seq
   encoding: base64
@@ -1384,12 +1380,12 @@
 - !ruby/object:MIME::Type
   content-type: application/deflate
   encoding: base64
+  obsolete: true
   xrefs:
     person:
     - David_Clunie
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 144
 - !ruby/object:MIME::Type
   content-type: application/dialog-info+xml
   encoding: base64
@@ -1443,8 +1439,7 @@
     template:
     - application/did
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 16
 - !ruby/object:MIME::Type
   content-type: application/dif+xml
   encoding: base64
@@ -2206,8 +2201,7 @@
     template:
     - application/geopose+json
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 16
 - !ruby/object:MIME::Type
   content-type: application/geoxacml+json
   encoding: base64
@@ -2318,8 +2312,7 @@
     template:
     - application/grib
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 16
 - !ruby/object:MIME::Type
   content-type: application/gxf
   encoding: base64
@@ -4447,8 +4440,7 @@
     template:
     - application/provided-claims+jwt
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 16
 - !ruby/object:MIME::Type
   content-type: application/prql
   friendly:
@@ -5773,8 +5765,7 @@
     template:
     - application/ST2110-41
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 16
 - !ruby/object:MIME::Type
   content-type: application/STEP
   encoding: base64
@@ -6106,8 +6097,7 @@
     template:
     - application/toc+cbor
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 16
 - !ruby/object:MIME::Type
   content-type: application/token-introspection+jwt
   encoding: base64
@@ -6318,8 +6308,7 @@
     template:
     - application/vc
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 16
 - !ruby/object:MIME::Type
   content-type: application/vc+cose
   encoding: base64
@@ -6330,8 +6319,7 @@
     template:
     - application/vc+cose
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 16
 - !ruby/object:MIME::Type
   content-type: application/vc+jwt
   encoding: base64
@@ -6342,8 +6330,7 @@
     template:
     - application/vc+jwt
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 16
 - !ruby/object:MIME::Type
   content-type: application/vcard+json
   encoding: base64
@@ -19556,12 +19543,12 @@
 - !ruby/object:MIME::Type
   content-type: application/voucher-cose+cbor
   encoding: base64
+  obsolete: true
   xrefs:
     draft:
     - draft-ietf-anima-constrained-voucher-17
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 144
 - !ruby/object:MIME::Type
   content-type: application/voucher-jws+json
   encoding: base64
@@ -19582,8 +19569,7 @@
     template:
     - application/vp
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 16
 - !ruby/object:MIME::Type
   content-type: application/vp+cose
   encoding: base64
@@ -19594,8 +19580,7 @@
     template:
     - application/vp+cose
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 16
 - !ruby/object:MIME::Type
   content-type: application/vp+jwt
   encoding: base64
@@ -19606,8 +19591,7 @@
     template:
     - application/vp+jwt
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 16
 - !ruby/object:MIME::Type
   content-type: application/vq-rtcpxr
   encoding: base64

--- a/types/audio.yaml
+++ b/types/audio.yaml
@@ -832,8 +832,7 @@
     template:
     - audio/midi-clip
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 16
 - !ruby/object:MIME::Type
   content-type: audio/mobile-xmf
   encoding: base64

--- a/types/image.yaml
+++ b/types/image.yaml
@@ -428,8 +428,7 @@
     template:
     - image/jxl
   registered: true
-  provisional: true
-  sort-priority: 79
+  sort-priority: 15
 - !ruby/object:MIME::Type
   content-type: image/jxr
   encoding: base64
@@ -550,12 +549,12 @@
 - !ruby/object:MIME::Type
   content-type: image/pdc
   encoding: base64
+  obsolete: true
   xrefs:
     person:
     - Pierre-Anthony_Lemieux
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 144
 - !ruby/object:MIME::Type
   content-type: image/pjpeg
   docs: Fixes a bug with IE6 and progressive JPEGs

--- a/types/video.yaml
+++ b/types/video.yaml
@@ -355,8 +355,7 @@
     template:
     - video/lottie+json
   registered: true
-  provisional: true
-  sort-priority: 80
+  sort-priority: 16
 - !ruby/object:MIME::Type
   content-type: video/matroska
   encoding: base64


### PR DESCRIPTION
The logic is three relatively simple phases:

1. When loading an existing registry grouping (such as `types/application.yaml`), we mark any type that is `provisional` as `obsolete`. This indicates that we consider any provisional type as potentially withdrawn (and therefore obsolete).

2. When processing existing regular types, we clear both `provisional` and `obsolete` flags so that a type promoted from provisional is now a regular registry entry.

3. After merging the current list of registry entries, we _clear_ `provisional` if the type is marked both `provisional` and `obsolete`, indicating that the provisional type has been withdrawn.

These heuristics match several types which have been promoted and withdrawn since the handling of provisional types was improved with [#53][pull-53].

Signed-off-by: Austin Ziegler <austin@zieglers.ca>
Resolves: #54
